### PR TITLE
Feature/morpho submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "Phylloxera"]
 	path = Phylloxera
 	url = https://github.com/project8/phylloxera.git
+[submodule "morpho"]
+	path = morpho
+	url = https://github.com/morphoorg/morpho.git
+	branch = master

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN mkdir -p $MERMITHID_BUILD_PREFIX &&\
 ########################
 FROM mermithid_common as mermithid_done
 
-COPY analysis /tmp_source/analysis
+# Commented out for now: should be changed to whatever is needed later
+# COPY analysis /tmp_source/analysis
 COPY Cicada /tmp_source/Cicada
 COPY documentation /tmp_source/documentation
 COPY morpho /tmp_source/morpho

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN mkdir -p $MERMITHID_BUILD_PREFIX &&\
 ########################
 FROM mermithid_common as mermithid_done
 
-# COPY . /tmp_source
 COPY analysis /tmp_source/analysis
 COPY Cicada /tmp_source/Cicada
 COPY documentation /tmp_source/documentation
@@ -51,4 +50,3 @@ RUN source $MERMITHID_BUILD_PREFIX/setup.sh &&\
     pip3 install . -e ./morpho --prefix $MERMITHID_BUILD_PREFIX &&\
     /bin/true
 
-    

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,14 @@ RUN mkdir -p $MERMITHID_BUILD_PREFIX &&\
 ########################
 FROM mermithid_common as mermithid_done
 
+# COPY . /tmp_source
+COPY analysis /tmp_source/analysis
 COPY Cicada /tmp_source/Cicada
+COPY documentation /tmp_source/documentation
+COPY morpho /tmp_source/morpho
 COPY mermithid /tmp_source/mermithid
 COPY Phylloxera /tmp_source/Phylloxera
+COPY tests /tmp_source/tests
 COPY CMakeLists.txt /tmp_source/CMakeLists.txt
 COPY setup.py /tmp_source/setup.py
 COPY .git /tmp_source/.git
@@ -33,7 +38,7 @@ COPY tests $MERMITHID_BUILD_PREFIX/tests
 # repeat the cmake command to get the change of install prefix to set correctly (a package_builder known issue)
 RUN source $MERMITHID_BUILD_PREFIX/setup.sh &&\
     cd /tmp_source &&\
-    mkdir build &&\
+    mkdir -p build &&\
     cd build &&\
     cmake -D CMAKE_BUILD_TYPE=$MERMITHID_BUILD_TYPE \
         -D CMAKE_INSTALL_PREFIX:PATH=$MERMITHID_BUILD_PREFIX \
@@ -43,10 +48,7 @@ RUN source $MERMITHID_BUILD_PREFIX/setup.sh &&\
         -D CMAKE_SKIP_INSTALL_RPATH:BOOL=True .. &&\
     make -j3 install &&\
     cd /tmp_source &&\
-    pip3 install . --process-dependency-links --prefix $MERMITHID_BUILD_PREFIX &&\
+    pip3 install . -e ./morpho --prefix $MERMITHID_BUILD_PREFIX &&\
     /bin/true
 
-########################
-FROM mermithid_common
-
-COPY --from=mermithid_done $MERMITHID_BUILD_PREFIX $MERMITHID_BUILD_PREFIX
+    

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ These are two possible ways of installing and working with mermithid.
 3. Install mermithid:
 
   ```bash
-  pip install . --process-dependency-links
+  pip install . -e ./morpho
   ```
 
-   (The `--process-dependency-links` is here to install morpho.)
+   (The `-e ./morpho` is here to install morpho as an egg.)
 
 ### Docker installation
 

--- a/documentation/install.rst
+++ b/documentation/install.rst
@@ -26,9 +26,9 @@ Inside your virtual environement, install mermithid: ::
 
 	source ~/path/to/the/virtual/environment/bin/activate # activate the virtual environement
 	echo $PYTHONPATH # make sure the build folder above is in this path
-	pip install . --process-dependency-links
+	pip install . -e ./morpho
 
-(The `--process-dependency-links` is here to install the right morpho version from github.)
+(The `-e ./morpho` is here to install the morpho version located in the `mermithid` top directory.)
 
 Docker installation
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -18,22 +18,10 @@ except Exception as err:
 
 on_rtd = os.environ.get("READTHEDOCS", None) == 'True'
 
-# Change tag and version number below
-MORPHO_TAG = "v2.5.0"
-MORPHO_HASH = '3ac7e8cd8056ed71741f83e1659093ac8b9c0963'
-
-# Don't touch below
-MORPHO_VERSION='{}-0-g{}'.format(MORPHO_TAG,MORPHO_HASH[:7])
-MORPHO_DEP_LINK = 'git+https://github.com/morphoorg/morpho.git@{0}#egg=morpho-{1}'.format(MORPHO_HASH,MORPHO_VERSION)
-MORPHO_REQ = "morpho=={0}".format(MORPHO_VERSION)
-
 requirements = []
 extras_require = {
-    'core':['colorlog', MORPHO_REQ],
-    'doc': ['sphinx','sphinx_rtd_theme','sphinxcontrib-programoutput', 'six', 'colorlog', MORPHO_REQ]
-}
-dep_links = {
-    MORPHO_DEP_LINK
+    'core':['colorlog', 'morpho'],
+    'doc': ['sphinx','sphinx_rtd_theme','sphinxcontrib-programoutput', 'six', 'colorlog', 'morpho']
 }
 
 if on_rtd:
@@ -54,7 +42,6 @@ setup(
     packages=find_packages(),
     install_requires=requirements,
     extras_require=extras_require,
-    dependency_links=dep_links,
     url='http://www.github.com/project8/mermithid',
     author = "M. Guigue",
     maintainer = "M. Guigue (PNNL)",

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ on_rtd = os.environ.get("READTHEDOCS", None) == 'True'
 
 requirements = []
 extras_require = {
-    'core':['colorlog', 'morpho'],
-    'doc': ['sphinx','sphinx_rtd_theme','sphinxcontrib-programoutput', 'six', 'colorlog', 'morpho']
+    'core':['colorlog'],
+    'doc': ['sphinx','sphinx_rtd_theme','sphinxcontrib-programoutput', 'six', 'colorlog']
 }
 
 if on_rtd:


### PR DESCRIPTION
Making morpho a git submodule of mermithid.

**Pros:**
- Easier to change morpho's version and install
- Better development workflow (integration with mermithid made regardless of morpho release scheme)
- Avoid using the depreciated `process-dependency-links` option (we can then now update the pip version to more modern ones...)

**Cons:**
- python experts are not very aware of this method (not sure they would even appreciate it); but maybe it doesn't matter much :)