### PR TITLE
Hotfix/1.2.3: New docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ${IMG_USER}/${IMG_REPO}:${IMG_TAG} as mermithid_common
 ARG build_type=Release
 ENV MERMITHID_BUILD_TYPE=$build_type
 
-ENV MERMITHID_TAG=v1.2.2
+ENV MERMITHID_TAG=v1.2.3
 ENV MERMITHID_BUILD_PREFIX=/usr/local/p8/mermithid/$MERMITHID_TAG
 
 RUN mkdir -p $MERMITHID_BUILD_PREFIX &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p $MERMITHID_BUILD_PREFIX &&\
     echo 'ln -sfT $MERMITHID_BUILD_PREFIX $MERMITHID_BUILD_PREFIX/../current' >> setup.sh &&\
     echo 'export PATH=$MERMITHID_BUILD_PREFIX/bin:$PATH' >> setup.sh &&\
     echo 'export LD_LIBRARY_PATH=$MERMITHID_BUILD_PREFIX/lib:$LD_LIBRARY_PATH' >> setup.sh &&\
-    echo 'export PYTHONPATH=$MERMITHID_BUILD_PREFIX/$(python -m site --user-site | sed "s%$(python -m site --user-base)%%"):$PYTHONPATH' >> setup.sh &&\
+    echo 'export PYTHONPATH=$MERMITHID_BUILD_PREFIX/$(python3 -m site --user-site | sed "s%$(python3 -m site --user-base)%%"):$PYTHONPATH' >> setup.sh &&\
     /bin/true
 
 ########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM project8/p8compute_dependencies:v0.9.0 as mermithid_common
+ARG IMG_USER=project8
+ARG IMG_REPO=p8compute_dependencies
+ARG IMG_TAG=v1.0.0.beta
+
+FROM ${IMG_USER}/${IMG_REPO}:${IMG_TAG} as mermithid_common
 
 ARG build_type=Release
 ENV MERMITHID_BUILD_TYPE=$build_type

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMG_USER=project8
 ARG IMG_REPO=p8compute_dependencies
-ARG IMG_TAG=v1.0.0.beta
+ARG IMG_TAG=v1.0.0
 
 FROM ${IMG_USER}/${IMG_REPO}:${IMG_TAG} as mermithid_common
 

--- a/documentation/validation_log.rst
+++ b/documentation/validation_log.rst
@@ -4,6 +4,18 @@ Validation Log
 Log
 ---
 
+Version: v1.2.3
+~~~~~~~~~~~~~~~~
+
+Release Date: Tues July 20 2021
+''''''''''''''''''''''''''''''
+
+Fixes:
+'''''''''''''
+
+* Updated mermithid and morpho submodule to handle PyROOT updates
+* Changed "python" to "python3" for Dockerfile and tests
+
 
 Version: v1.2.2
 ~~~~~~~~~~~~~~~~

--- a/mermithid/processors/TritiumSpectrum/DistortedTritiumSpectrumLikelihoodSampler.py
+++ b/mermithid/processors/TritiumSpectrum/DistortedTritiumSpectrumLikelihoodSampler.py
@@ -142,7 +142,7 @@ class DistortedTritiumSpectrumLikelihoodSampler(RooFitInterfaceProcessor):
             # Spectrum smearing
             gauss = ROOT.RooGaussian("gauss","gauss",var,meanSmearing,widthSmearing)
             smearedspectrum = pdffactory.GetSmearedPdf(ROOT.RealTritiumFrequencySpectrum)("smearedspectrum", 2, var, shapePdf, meanSmearing, widthSmearing,100000)
-            pdf = pdffactory.AddBackground(ROOT.RooAbsPdf)("pdf",var,smearedspectrum,NEvents,NBkgd)
+            pdf = pdffactory.AddBackground[ROOT.RooAbsPdf]("pdf",var,smearedspectrum,NEvents,NBkgd)
 
 
         if "snr_efficiency" in self.options and self.options["snr_efficiency"]:
@@ -180,12 +180,12 @@ class DistortedTritiumSpectrumLikelihoodSampler(RooFitInterfaceProcessor):
                 # x is Frequency in channel in MHz: (@0*TMath::Power(10, -6)-cf)
                 channelEffFunc = ROOT.RooFormulaVar("channel_efficiency", "channel_efficiency", "c4 * TMath::Sqrt(1/(1 + 1*TMath::Power((@0*TMath::Power(10, -6)-cf)/c0, c1)))* TMath::Sqrt(1/(1 + TMath::Power((@0*TMath::Power(10, -6)-cf)/c2, c3)))", channel_eff_coeff)
                 superDistortedSpectrum = ROOT.RooEffProd("superDistortedSpectrum", "superDistortedSpectrum", distortedSpectrum, channelEffFunc)
-                pdf = pdffactory.AddBackground(ROOT.RooAbsPdf)("pdf",var,superDistortedSpectrum,NEvents,NBkgd)
+                pdf = pdffactory.AddBackground[ROOT.RooAbsPdf]("pdf",var,superDistortedSpectrum,NEvents,NBkgd)
 
             else:
-                pdf = pdffactory.AddBackground(ROOT.RooAbsPdf)("pdf",var,distortedSpectrum,NEvents,NBkgd)
+                pdf = pdffactory.AddBackground[ROOT.RooAbsPdf]("pdf",var,distortedSpectrum,NEvents,NBkgd)
         else:
-            pdf = pdffactory.AddBackground(ROOT.RooAbsPdf)("pdf",var,shapePdf,NEvents,NBkgd)
+            pdf = pdffactory.AddBackground[ROOT.RooAbsPdf]("pdf",var,shapePdf,NEvents,NBkgd)
 
 
 

--- a/mermithid/processors/TritiumSpectrum/TritiumSpectrumGenerator.py
+++ b/mermithid/processors/TritiumSpectrum/TritiumSpectrumGenerator.py
@@ -85,7 +85,7 @@ class TritiumSpectrumGenerator(BaseProcessor):
                 "meanSmearing_tmp", "meanSmearing_tmp", 0)
             widthSmearing = ROOT.RooRealVar(
                 "widthSmearing_tmp", "widthSmearing_tmp", self.energy_resolution)
-            smearedspectrum = pdffactory.GetSmearedPdf(ROOT.RealTritiumSpectrum)(
+            smearedspectrum = pdffactory.GetSmearedPdf[ROOT.RealTritiumSpectrum](
                 "smearedspectrum_tmp", 2, KE, spectrum, meanSmearing, widthSmearing, 1000000)
         fullSpectrumIntegral = spectrum.createIntegral(
             ROOT.RooArgSet(KE), ROOT.RooFit.Range("FullRange"))
@@ -141,7 +141,7 @@ class TritiumSpectrumGenerator(BaseProcessor):
             widthSmearing = ROOT.RooRealVar(
                 "widthSmearing", "widthSmearing", self.energy_resolution, 0., 10*self.energy_resolution)
             # KE.setBins(100000, "cache")
-            smearedspectrum = pdffactory.GetSmearedPdf(ROOT.RealTritiumSpectrum)(
+            smearedspectrum = pdffactory.GetSmearedPdf[ROOT.RealTritiumSpectrum](
                 "smearedspectrum", 2, KE, spectrum, meanSmearing, widthSmearing, 100000)
 
         # Background
@@ -185,10 +185,10 @@ class TritiumSpectrumGenerator(BaseProcessor):
         NBkgd = ROOT.RooRealVar(
             "NBkgd", "NBkgd", self.number_bkgd_window_to_generate, 0., 10*self.number_bkgd_window_to_generate)
         if self.doSmearing:
-            totalSpectrum = pdffactory.AddBackground(ROOT.RooAbsPdf)(
+            totalSpectrum = pdffactory.AddBackground[ROOT.RooAbsPdf](
                 "totalSpectrum", KE, smearedspectrum, NEvents, NBkgd)
         else:
-            totalSpectrum = pdffactory.AddBackground(ROOT.RooAbsPdf)(
+            totalSpectrum = pdffactory.AddBackground[ROOT.RooAbsPdf](
                 "totalSpectrum", KE, spectrum, NEvents, NBkgd)
 
         # Save things in a Workspace

--- a/mermithid/processors/TritiumSpectrum/TritiumSpectrumProcessor.py
+++ b/mermithid/processors/TritiumSpectrum/TritiumSpectrumProcessor.py
@@ -73,7 +73,7 @@ class TritiumSpectrumProcessor(RooFitInterfaceProcessor):
                 "meanSmearing_tmp", "meanSmearing_tmp", 0)
             widthSmearing = ROOT.RooRealVar(
                 "widthSmearing_tmp", "widthSmearing_tmp", self.energy_resolution)
-            spectrum = pdffactory.GetSmearedPdf(ROOT.RealTritiumSpectrum)(
+            spectrum = pdffactory.GetSmearedPdf[ROOT.RealTritiumSpectrum](
                 "smearedspectrum_tmp", 2, KE, spectrum, meanSmearing, widthSmearing, 1000000)
         fullSpectrumIntegral = spectrum.createIntegral(
             ROOT.RooArgSet(KE), ROOT.RooFit.Range("FullRange"))
@@ -128,7 +128,7 @@ class TritiumSpectrumProcessor(RooFitInterfaceProcessor):
             meanSmearing = ROOT.RooRealVar("meanSmearing", "meanSmearing", 0.)
             widthSmearing = ROOT.RooRealVar(
                 "widthSmearing", "widthSmearing", self.energy_resolution, 0., 10*self.energy_resolution)
-            smearedspectrum = pdffactory.GetSmearedPdf(ROOT.RealTritiumSpectrum)(
+            smearedspectrum = pdffactory.GetSmearedPdf[ROOT.RealTritiumSpectrum](
                 "smearedspectrum", 2, KE, spectrum, meanSmearing, widthSmearing, 100000)
 
         # Calculate number of events and background
@@ -168,10 +168,10 @@ class TritiumSpectrumProcessor(RooFitInterfaceProcessor):
         NBkgd = ROOT.RooRealVar(
             "NBkgd", "NBkgd", self.number_bkgd_window_to_generate, 0., 10*self.number_bkgd_window_to_generate)
         if self.doSmearing:
-            pdf = pdffactory.AddBackground(ROOT.RooAbsPdf)(
+            pdf = pdffactory.AddBackground[ROOT.RooAbsPdf](
                 "pdf", KE, smearedspectrum, NEvents, NBkgd)
         else:
-            pdf = pdffactory.AddBackground(ROOT.RooAbsPdf)(
+            pdf = pdffactory.AddBackground[ROOT.RooAbsPdf](
                 "pdf", KE, spectrum, NEvents, NBkgd)
 
         getattr(wspace, 'import')(KE)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-python IO_test.py
-python Misc_test.py
-python Tritium_test.py
-python TritiumAndEfficiencyBinner_test.py
-python Fake_data_generator_test.py
+python3 IO_test.py
+python3 Misc_test.py
+python3 Tritium_test.py
+python3 TritiumAndEfficiencyBinner_test.py
+python3 Fake_data_generator_test.py


### PR DESCRIPTION
The base image is now p8compute_dependencies:v1.0.0, which is based on Ubuntu 20.04 instead of CentOS.

Testing the build locally worked for me.