### PR TITLE
Feature added: trapping efficiency calculation from trap shape

### DIFF
--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -188,7 +188,7 @@ def trapping_efficiency(z_range, percent_radial_field_increase, bg_magnetic_fiel
 
 
 
-###############################################################################
+###############################################################################cd
 class CavitySensitivity(Sensitivity):
     """
     Documentation:

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -130,14 +130,14 @@ def t_effective(t_physical, cyclotron_frequency):
        return quantum*(1/2+1/(np.exp(quantum/t_physical)-1))
 
 # Trapping efficiency from axial field variation.
-def trapping_efficiency(z_range, bg_magnetic_field, min_pitch_angle, trap_flat_fraction = 0.5, plotting=False):
+def trapping_efficiency(z_range, bg_magnetic_field, min_pitch_angle, trap_flat_fraction = 0.5):
 
     """
     Calculate the trapping efficiency for a given trap length and flat fraction.
 
     The trapping efficiency is computed using the formula:
-        epsilon(z) = sqrt(del_B(z)/B_max(z))
-    where del_B(z)=B_max(z)-B(z), B(z) is the magnetic field at position z, and B_max(z) is the maximum magnetic field along the z axis.
+        epsilon(z) = sqrt(1 - B(z)/B_max(z))
+    where B(z) is the magnetic field at position z, and B_max(z) is the maximum magnetic field along the z axis.
 
     Parameters
     ----------
@@ -149,8 +149,6 @@ def trapping_efficiency(z_range, bg_magnetic_field, min_pitch_angle, trap_flat_f
         Minimum pitch angle to be trapped.
     trap_flat_fraction : float, optional
         Flat fraction of the trap. Default is 0.5.
-    plotting : bool, optional
-        If True, generates plots of the trapping efficiency. Default is False.
 
     Returns
     -------
@@ -174,8 +172,8 @@ def trapping_efficiency(z_range, bg_magnetic_field, min_pitch_angle, trap_flat_f
     #Calculate maximum trapping field along z (Bz_max)
     maximum_Bz = max(profiles)
 
-    #Calculate mean trapping efficiency using mean of epsilon(z) = sqrt(del_B(z)/B_max(z))
-    mean_efficiency = np.mean(np.array([np.sqrt((maximum_Bz-b_at_z)/b_at_z) for b_at_z in profiles]))
+    #Calculate mean trapping efficiency using mean of epsilon(z) = sqrt(1-B(z)/B_max(z)) at z = 0
+    mean_efficiency = np.mean(np.array([np.sqrt(1-b_at_z/maximum_Bz) for b_at_z in profiles]))
 
     return mean_efficiency
 
@@ -205,8 +203,8 @@ class CavitySensitivity(Sensitivity):
         self.pos_dependent_trapping_efficiency = trapping_efficiency( z_range = self.Experiment.trap_length /2,
                                                                     bg_magnetic_field = self.MagneticField.nominal_field, 
                                                                     min_pitch_angle = self.FrequencyExtraction.minimum_angle_in_bandwidth, 
-                                                                    trap_flat_fraction = self.MagneticField.trap_flat_fraction, 
-                                                                    plotting= True)        
+                                                                    trap_flat_fraction = self.MagneticField.trap_flat_fraction
+                                                                    )        
  
         self.CavityRadius()
         self.CavityVolume()

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -163,7 +163,7 @@ def trapping_efficiency(z_range, bg_magnetic_field, min_pitch_angle, trap_flat_f
     The mean trapping efficiency is averaged over the region where the trapping field exists.
     """
 
-    zs = np.linspace(-z_range, z_range, 100)
+    zs = np.linspace(-z_range, z_range, 500)
 
     profiles = []
     #Collect z profile of the magnetic field
@@ -175,7 +175,7 @@ def trapping_efficiency(z_range, bg_magnetic_field, min_pitch_angle, trap_flat_f
 
     #Calculate mean trapping efficiency using mean of epsilon(z) = sqrt(1-B(z)/B_max(z)) at z = 0
     mean_efficiency = np.mean(np.array([np.sqrt(1-b_at_z/maximum_Bz) for b_at_z in profiles]))
-
+    
     return mean_efficiency
 
 
@@ -206,7 +206,6 @@ class CavitySensitivity(Sensitivity):
                                                                     min_pitch_angle = self.FrequencyExtraction.minimum_angle_in_bandwidth, 
                                                                     trap_flat_fraction = self.MagneticField.trap_flat_fraction
                                                                     )             
-
         """
         if hasattr(self.FrequencyExtraction, "trap_q"):
             self.q = self.FrequencyExtraction.trap_q

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -130,21 +130,21 @@ def t_effective(t_physical, cyclotron_frequency):
        return quantum*(1/2+1/(np.exp(quantum/t_physical)-1))
 
 # Trapping efficiency from axial field variation.
-def trapping_efficiency(z_range, radial_field_variation, bg_magnetic_field, min_pitch_angle, trap_flat_fraction = 0.5, plotting=False):
+def trapping_efficiency(z_range, percent_radial_field_increase, bg_magnetic_field, min_pitch_angle, trap_flat_fraction = 0.5, plotting=False):
 
     """
     Calculate the trapping efficiency for a given trap length and flat fraction.
 
     The trapping efficiency is computed using the formula:
-        epsilon(z) = sqrt(1 - B(z)/B_max(z))
+        epsilon(z) = sqrt(del_B(z)/B_max(z))
     where B(z) is the magnetic field at position z, and B_max(z) is the maximum magnetic field along the z axis.
 
     Parameters
     ----------
     z_range : float
         The axial range (in z-direction, from trap center) over which electron trapping happens.
-    radial_field_variation : float
-        Predefined radial variation of magnetic fields, constant for all z's, temporary solution for efficiency calculation. 
+    percent_radial_field_increase : float
+        Predefined percent radial increase of magnetic field due to radial trap profile, same value for all z's, temporary solution for trapping efficiency calculation. 
     bg_magnetic_field : float
         The background magnetic field.
     min_pitch_angle : float
@@ -157,22 +157,32 @@ def trapping_efficiency(z_range, radial_field_variation, bg_magnetic_field, min_
     Returns
     -------
     mean_efficiency : float
-        The mean trapping efficiency across the specified trapping range.
+        The mean trapping efficiency across the trap z-range.
 
     Notes
     -----
     The magnetic field profile is computed using the `magnetic_field_flat_harmonic` function, currently it only produces z-profile of the trap without radial variation. 
-    Radial variation is assumed to be constant for all radii, and set during function call.
-    The mean trapping efficiency is averaged over the region where the field is non-zero.
+    Radial variation is assumed to be maximum at the edge of the cavity, and only one epsilon_z(r) is calculated at each z (at r = 0), an ideal calculation would evaluate this at different r's. 
+    Maximum percent variation can be set during function call or from configuration.
+    The mean trapping efficiency is averaged over the region where the trapping field exists.
     """
+    #Warn user if no radial variation
+    if percent_radial_field_increase == 0:
+        logger.info("No radial variation given for the electron-trap, try using a fixed efficiency or a non-zero \'percent_radial_variation\'")
 
     zs = np.linspace(-z_range, z_range, 100)
 
     profiles = []
+    #Collect z profile of the magnetic field
     for z in zs:
         profiles.append(magnetic_field_flat_harmonic(z, bg_magnetic_field, z_range*2, min_pitch_angle, trap_flat_fraction))
+    
+    #Calculate radial variation from trap depth and percent variation
 
-    mean_efficiency = np.mean(np.array([np.mean(np.sqrt(radial_field_variation/b_at_z)) for b_at_z in profiles])) 
+    radial_field_variation = (max(profiles)-min(profiles))*percent_radial_field_increase/100
+
+    #Calculate mean trapping efficiency using mean of epsilon(z) = sqrt(del_B(z)/B_max(z))
+    mean_efficiency = np.mean(np.array([np.sqrt(radial_field_variation/b_at_z) for b_at_z in profiles]))
 
     return mean_efficiency
 
@@ -200,7 +210,7 @@ class CavitySensitivity(Sensitivity):
 
         #Calculate position dependent trapping efficiency
         self.pos_dependent_trapping_efficiency = trapping_efficiency( z_range = self.Experiment.trap_length /2,
-                                                                    radial_field_variation = 0.01*mT if not self.MagneticField.radial_variation else self.MagneticField.radial_variation,
+                                                                    percent_radial_field_increase = self.MagneticField.percent_radial_variation,
                                                                     bg_magnetic_field = self.MagneticField.nominal_field, 
                                                                     min_pitch_angle = self.FrequencyExtraction.minimum_angle_in_bandwidth, 
                                                                     trap_flat_fraction = self.MagneticField.trap_flat_fraction, 
@@ -498,10 +508,10 @@ class CavitySensitivity(Sensitivity):
             frac_uncertainty = self.MagneticField.fraction_uncertainty_on_field_broadening
             sigma_meanB = self.MagneticField.sigma_meanb
             sigmaE_meanB = self.BToKeErr(sigma_meanB*B, B)
-            sigmaE_r = self.MagneticField.sigmae_r
+            sigmaE_r_non_trap = self.MagneticField.sigmae_r_non_trap_effects
             sigmaE_theta = self.MagneticField.sigmae_theta
             sigmaE_phi = self.MagneticField.sigmae_theta
-            sigma = np.sqrt(sigmaE_meanB**2 + sigmaE_r**2 + sigmaE_theta**2 + sigmaE_phi**2)
+            sigma = np.sqrt(sigmaE_meanB**2 + sigmaE_r_non_trap**2 + sigmaE_theta**2 + sigmaE_phi**2)
             return sigma, frac_uncertainty*sigma
         else:
             return 0, 0

--- a/test_analysis/Cavity_Sensitivity_analysis.py
+++ b/test_analysis/Cavity_Sensitivity_analysis.py
@@ -150,7 +150,7 @@ sens_config_dict = {
 sens_config_dict = {
     # required
     "config_file_path": "/termite/sensitivity_config_files/Config_LFA_Experiment_max_BNL_diam.cfg", #"/termite/sensitivity_config_files/Config_LFA_Experiment_1GHz.cfg", #Config_atomic_325MHz_Experiment_conservative.cfg",
-    "plot_path": "./LFA_and_PhaseIV_sensitivity_vs_density_fflat_0.75_Dec-17-2024.pdf",
+    "plot_path": "./LFA_and_PhaseIV_sensitivity_vs_density_tests_Dec-17-2024.pdf",
     # optional
     "figsize": (7.0,6), 
     "fontsize": 15,


### PR DESCRIPTION
### New Feature

- Added code-block for trapping efficiency calculations doe to magnetic field variations, using a given radial variation
- Outputs trapping efficiency alongside other efficiencies

### Tests Performed

- Tests performed with a few different radial variations
- Produces correct efficiencies with clear effects on final sensitivity
- No known issues

### Notes

Since the mermithid trap does not have radial variation, this feature uses a predefined constant radial variation. This can be assigned through termite (after pulling the latest 'feature/sensitivity_config_files' branch).