### PR TITLE
Feature/sensitivity curve link rf background and detection efficiency to snr

### DIFF
--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -156,6 +156,8 @@ class CavitySensitivity(Sensitivity):
         self.EffectiveVolume()
         self.PitchDependentTrappingEfficiency()
         self.CavityPower()
+        self.assign_background_rate_from_threshold()
+        self.assign_detection_efficiency_from_threshold()
 
         #Get trap length from cavity length if not specified
         if self.Experiment.trap_length == 0:
@@ -462,9 +464,15 @@ class CavitySensitivity(Sensitivity):
     def rf_background_rate_cavity(self):
         return chi2(df=2).sf(self.threshold)
 
-    def assign_background_rate(self):
+    def assign_background_rate_from_threshold(self):
         self.Experiment.RF_background_rate_per_eV = rf_background_rate_cavity(self)
-        return None
+        return self.Experiment.RF_background_rate_per_eV
+
+    def assign_detection_efficiency_from_threshold(self):
+        effective_volume_before_modified = EffectiveVolume(self)
+        self.effective_volume = effective_volume_before_modified*det_efficiency_tau(self)
+        return self.effective_volume
+        
     
     # PRINTS
     def print_SNRs(self, rho=None):

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -453,9 +453,9 @@ class CavitySensitivity(Sensitivity):
             return 0, 0
 
     def det_efficiency_tau(self, threshold):
-       tau_snr_ex_carrier = self.calculate_tau_snr(track_duration, self.FrequencyExtraction.carrier_power_fraction)
-       track_duration = self.time_window
-       return quad(lambda tau: ncx2(df=2, nc= tau_snr_ex_carrier).sf(threshold)*1/track_duration*np.exp(-tau/track_duration), 0, np.infty)[0]
+        tau_snr_ex_carrier = self.calculate_tau_snr(track_duration, self.FrequencyExtraction.carrier_power_fraction)
+        track_duration = self.time_window
+        return quad(lambda tau: ncx2(df=2, nc= tau_snr_ex_carrier).sf(threshold)*1/track_duration*np.exp(-tau/track_duration), 0, np.infty)[0]
         
     
     # PRINTS

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -7,6 +7,8 @@ The statistical method and formulas are described in
 CDR (CRES design report, Section 1.3) https://www.overleaf.com/project/5b9314afc673d862fa923d53.
 '''
 import numpy as np
+from scipy.stats import ncx2, chi2
+from scipy.integrate import quad
 
 from mermithid.misc.Constants_numericalunits import *
 from mermithid.misc.CRESFunctions_numericalunits import *

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -454,14 +454,17 @@ class CavitySensitivity(Sensitivity):
         else:
             return 0, 0
 
-    def det_efficiency_tau(self, threshold):
+    def det_efficiency_tau(self):
         tau_snr_ex_carrier = self.calculate_tau_snr(track_duration, self.FrequencyExtraction.carrier_power_fraction)
         track_duration = self.time_window
-        return quad(lambda tau: ncx2(df=2, nc= tau_snr_ex_carrier).sf(threshold)*1/track_duration*np.exp(-tau/track_duration), 0, np.infty)[0]
+        return quad(lambda tau: ncx2(df=2, nc= tau_snr_ex_carrier).sf(self.threshold)*1/track_duration*np.exp(-tau/track_duration), 0, np.infty)[0]
 
-    def background_rate(self, threshold):
-        return chi2(df=2).sf(threshold)
-        
+    def rf_background_rate_cavity(self):
+        return chi2(df=2).sf(self.threshold)
+
+    def assign_background_rate(self):
+        self.Experiment.RF_background_rate_per_eV = rf_background_rate_cavity(self)
+        return None
     
     # PRINTS
     def print_SNRs(self, rho=None):

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -451,6 +451,11 @@ class CavitySensitivity(Sensitivity):
             return sigma, frac_uncertainty*sigma
         else:
             return 0, 0
+
+    def det_efficiency_tau(self, threshold):
+       tau_snr_ex_carrier = self.calculate_tau_snr(track_duration, self.FrequencyExtraction.carrier_power_fraction)
+       track_duration = self.time_window
+       return quad(lambda tau: ncx2(df=2, nc= tau_snr_ex_carrier).sf(threshold)*1/track_duration*np.exp(-tau/track_duration), 0, np.infty)[0]
         
     
     # PRINTS

--- a/mermithid/sensitivity/SensitivityCavityFormulas.py
+++ b/mermithid/sensitivity/SensitivityCavityFormulas.py
@@ -456,6 +456,9 @@ class CavitySensitivity(Sensitivity):
         tau_snr_ex_carrier = self.calculate_tau_snr(track_duration, self.FrequencyExtraction.carrier_power_fraction)
         track_duration = self.time_window
         return quad(lambda tau: ncx2(df=2, nc= tau_snr_ex_carrier).sf(threshold)*1/track_duration*np.exp(-tau/track_duration), 0, np.infty)[0]
+
+    def background_rate(self, threshold):
+        return chi2(df=2).sf(threshold)
         
     
     # PRINTS

--- a/test_analysis/Cavity_Sensitivity_analysis.py
+++ b/test_analysis/Cavity_Sensitivity_analysis.py
@@ -168,7 +168,7 @@ sens_config_dict = {
     "comparison_curve": True,
     "main_curve_color": "blue",
     "comparison_curve_colors": ["red"], # "black"],
-    "comparison_config_file_path": ["/termite/sensitivity_config_files/Config_atomic_150MHz_minpitch_87deg.cfg"], 
+    "comparison_config_file_path": ["/termite/sensitivity_config_files/Config_LFA_Experiment_max_BNL_diam.cfg"], 
     "comparison_curve_label": [r"Phase IV scenario: 150 MHz"],
     "comparison_label_y_position": [2, 0.105, 0.046], #[2, 0.105, 0.046],
     "comparison_label_x_position": [4.5e15, 7e14, 7e14], #[4.5e15, 2.2e16, 1e15],
@@ -403,6 +403,7 @@ sens_config_dict = {
     "goals_x_position": 1.2e12, #0.0002
     "plot_key_parameters": True
     }
+
 #sens_curve = CavitySensitivityCurveProcessor("sensitivity_curve_processor")
 #sens_curve.Configure(sens_config_dict)
 #sens_curve.Run()


### PR DESCRIPTION
The added feature is to consider the effect of the SNR on the background rate and the detection efficiency based on René's work: https://3.basecamp.com/3700981/buckets/3107037/documents/8013439062. https://3.basecamp.com/3700981/buckets/3107037/documents/7572536796#__recording_7616690029. The configure file is in https://github.com/project8/termite/blob/background_rate_and_detection_efficiency_as_functions_of_SNR/sensitivity_config_files/Config_LFA_Experiment_max_BNL_diam.cfg. The processor is running for now. I'm sending a pull request. 